### PR TITLE
fix: escape > in Netlify step

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -111,7 +111,7 @@ const App: React.FC = () => {
           >
             <ol className="list-decimal list-inside space-y-3 text-gray-300">
               <li>Sign up or log in to your <a href="https://app.netlify.com" target="_blank" rel="noopener noreferrer" className="text-cyan-400 hover:text-cyan-300 underline">Netlify account</a>.</li>
-              <li>Click "Add new site" > "Import from Git".</li>
+                <li>Click "Add new site" &gt; "Import from Git".</li>
               <li>Connect to GitHub and select the repository you just pushed.</li>
               <li>Netlify automatically detects Vite project settings. The defaults are usually correct:
                 <ul className="list-disc list-inside ml-6 mt-2 p-3 bg-gray-800/50 rounded-md text-sm">


### PR DESCRIPTION
## Summary
- escape > in Netlify deployment step to satisfy TSX parser

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c39e490ad883308c3e76c34b4a4233