### PR TITLE
Use unified API_KEY for Google services

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -168,8 +168,8 @@ export { handler };`} />
 SUPABASE_URL=your-project-url
 SUPABASE_ANON_KEY=your-public-anon-key
 
-# Google Gemini API
-API_KEY=your-google-api-key
+  # Google APIs (Gemini, Cloud Vision)
+  API_KEY=your-google-api-key
 
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_...

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1obfZF7oOAe0Q_QEMBWYn_F
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `API_KEY` in [.env.local](.env.local) to your Google API key (used for both Gemini and Cloud Vision)
 3. Run the app:
    `npm run dev`

--- a/netlify/functions/vision.ts
+++ b/netlify/functions/vision.ts
@@ -5,12 +5,12 @@ const sampleImage =
   "iVBORw0KGgoAAAANSUhEUgAAAMgAAABGCAIAAAAGgExhAAACI0lEQVR4nO3asYriQACH8dmLuKKFaUVs9AGstBGCgpWlpQoWAd/BJ/AhBAvrgKWWFhaSJ7ASRAQ7bQwIYq4Q5LiVDXj353a971fNmJGM8MUE8S0MQwP8bT/+9QbwmggLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAWJ6LBs2/5k+vDQJ2vwn+AbCxJPhnU4HDqdTr1edxzH9/2Ha/b7faPRcByn0Wjs9/s/2CS+oTBKOp3+OHVdd7lchmG42WyKxeJvK2+DVqs1Ho/DMByPx+12O/JEeCVvYdT/sZLJZLlcvk993w+CIJfLFQqF2yu73W61WlmWZdv28Xg0xtwG2Wx2vV6/v7+fz+d8Pr/b7WRXB76cWOSKeDw+n8/v09uD+eVymc1miUTier0uFgvLsj6+MTJZvLAnn7EqlcpkMjHGTKfTwWDwcE2tVvM8zxjjeV61Wn12h/iWom+F9xvcr9Ptdtvr9YIgiMViw+Ewn88bY0qlUrPZ7Pf7t0G323Vd93Q6pVKp0WiUyWSknwRfSnRYwBP4HQsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsSPwElPa4nkCj/vAAAAABJRU5ErkJggg==";
 
 const handler: Handler = async () => {
-  const apiKey = process.env.GOOGLE_VISION_API_KEY;
+  const apiKey = process.env.API_KEY;
 
   if (!apiKey) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: "Missing GOOGLE_VISION_API_KEY environment variable" }),
+      body: JSON.stringify({ error: "Missing API_KEY environment variable" }),
     };
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(env.API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- Use `API_KEY` for both Gemini and Cloud Vision
- Remove service-specific API key variables from configuration
- Update docs and sample config to reflect shared Google API key

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c420b3ad908330a9a88c11b961e4de