### PR TITLE
Use unified API_KEY for Google services

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ const App: React.FC = () => {
   const [pingStatus, setPingStatus] = useState<Status>('idle');
   const [supabaseStatus, setSupabaseStatus] = useState<Status>('idle');
   const [visionStatus, setVisionStatus] = useState<Status>('idle');
+  const [geminiStatus, setGeminiStatus] = useState<Status>('idle');
 
   const handlePing = useCallback(async () => {
     setPingStatus('loading');
@@ -72,6 +73,19 @@ const App: React.FC = () => {
     } catch (error) {
       console.error("Failed to call Vision API:", error);
       setVisionStatus('error');
+    }
+  }, []);
+
+  const handleTestGemini = useCallback(async () => {
+    setGeminiStatus('loading');
+    try {
+      const response = await fetch('/.netlify/functions/gemini');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      await response.json();
+      setGeminiStatus('success');
+    } catch (error) {
+      console.error("Failed to call Gemini API:", error);
+      setGeminiStatus('error');
     }
   }, []);
 
@@ -168,8 +182,8 @@ export { handler };`} />
 SUPABASE_URL=your-project-url
 SUPABASE_ANON_KEY=your-public-anon-key
 
-# Google Gemini API
-API_KEY=your-google-api-key
+  # Google APIs (Gemini, Cloud Vision)
+  API_KEY=your-google-api-key
 
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_...
@@ -269,6 +283,23 @@ insert into notes (title) values ('This is a test note');`} />
                     className="bg-blue-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-blue-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-blue-500"
                   >
                     {visionStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Gemini API Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Gemini API</p>
+                  <p className="font-mono text-xs text-gray-500">/gemini</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={geminiStatus} /></div>
+                  <button
+                    onClick={handleTestGemini}
+                    disabled={geminiStatus === 'loading'}
+                    className="bg-purple-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-purple-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-purple-500"
+                  >
+                    {geminiStatus === 'loading' ? 'Testing...' : 'Test'}
                   </button>
                 </div>
               </div>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ View your app in AI Studio: https://ai.studio/apps/drive/1obfZF7oOAe0Q_QEMBWYn_F
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `API_KEY` in [.env.local](.env.local) to your Google API key (used for both Gemini and Cloud Vision)
 3. Run the app:
    `npm run dev`
+
+The project includes sample Netlify functions for Ping, Supabase, Cloud Vision, and Gemini that you can invoke from the UI to verify your environment configuration.

--- a/netlify/functions/gemini.ts
+++ b/netlify/functions/gemini.ts
@@ -1,0 +1,51 @@
+import type { Handler } from "@netlify/functions";
+
+const handler: Handler = async () => {
+  const apiKey = process.env.API_KEY;
+
+  if (!apiKey) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing API_KEY environment variable" }),
+    };
+  }
+
+  const body = {
+    contents: [
+      {
+        parts: [{ text: "Hello" }],
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: response.status, body: text };
+    }
+
+    const data = await response.json();
+    const generatedText = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ text: generatedText }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};
+
+export { handler };

--- a/netlify/functions/vision.ts
+++ b/netlify/functions/vision.ts
@@ -5,12 +5,12 @@ const sampleImage =
   "iVBORw0KGgoAAAANSUhEUgAAAMgAAABGCAIAAAAGgExhAAACI0lEQVR4nO3asYriQACH8dmLuKKFaUVs9AGstBGCgpWlpQoWAd/BJ/AhBAvrgKWWFhaSJ7ASRAQ7bQwIYq4Q5LiVDXj353a971fNmJGM8MUE8S0MQwP8bT/+9QbwmggLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAWJ6LBs2/5k+vDQJ2vwn+AbCxJPhnU4HDqdTr1edxzH9/2Ha/b7faPRcByn0Wjs9/s/2CS+oTBKOp3+OHVdd7lchmG42WyKxeJvK2+DVqs1Ho/DMByPx+12O/JEeCVvYdT/sZLJZLlcvk993w+CIJfLFQqF2yu73W61WlmWZdv28Xg0xtwG2Wx2vV6/v7+fz+d8Pr/b7WRXB76cWOSKeDw+n8/v09uD+eVymc1miUTier0uFgvLsj6+MTJZvLAnn7EqlcpkMjHGTKfTwWDwcE2tVvM8zxjjeV61Wn12h/iWom+F9xvcr9Ptdtvr9YIgiMViw+Ewn88bY0qlUrPZ7Pf7t0G323Vd93Q6pVKp0WiUyWSknwRfSnRYwBP4HQsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsSPwElPa4nkCj/vAAAAABJRU5ErkJggg==";
 
 const handler: Handler = async () => {
-  const apiKey = process.env.GOOGLE_VISION_API_KEY;
+  const apiKey = process.env.API_KEY;
 
   if (!apiKey) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: "Missing GOOGLE_VISION_API_KEY environment variable" }),
+      body: JSON.stringify({ error: "Missing API_KEY environment variable" }),
     };
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(env.API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- Use `API_KEY` for both Gemini and Cloud Vision
- Remove service-specific API key variables from configuration
- Add Gemini Netlify function and UI test using shared `API_KEY`
- Update docs and sample config to reflect shared Google API key and available test functions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c420b3ad908330a9a88c11b961e4de