### PR TITLE
Add Stripe and Brevo API health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+package-lock.json

--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { Card } from './components/Card';
 import { CodeBlock } from './components/CodeBlock';
 import { GithubIcon, NetlifyIcon, ReactIcon, ViteIcon, ServerIcon, SupabaseIcon } from './components/icons';
+import { loadStripe } from '@stripe/stripe-js';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -23,6 +24,9 @@ const App: React.FC = () => {
   const [pingStatus, setPingStatus] = useState<Status>('idle');
   const [supabaseStatus, setSupabaseStatus] = useState<Status>('idle');
   const [visionStatus, setVisionStatus] = useState<Status>('idle');
+  const [geminiStatus, setGeminiStatus] = useState<Status>('idle');
+  const [stripeStatus, setStripeStatus] = useState<Status>('idle');
+  const [brevoStatus, setBrevoStatus] = useState<Status>('idle');
 
   const handlePing = useCallback(async () => {
     setPingStatus('loading');
@@ -75,6 +79,48 @@ const App: React.FC = () => {
     }
   }, []);
 
+  const handleTestGemini = useCallback(async () => {
+    setGeminiStatus('loading');
+    try {
+      const response = await fetch('/.netlify/functions/gemini');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      await response.json();
+      setGeminiStatus('success');
+    } catch (error) {
+      console.error("Failed to call Gemini API:", error);
+      setGeminiStatus('error');
+    }
+  }, []);
+
+  const handleTestStripe = useCallback(async () => {
+    setStripeStatus('loading');
+    try {
+      const stripe = await loadStripe(process.env.STRIPE_PUBLISHABLE_KEY || '');
+      if (!stripe) throw new Error('Stripe failed to load');
+      const response = await fetch('/.netlify/functions/stripe');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const { clientSecret } = await response.json();
+      const pi = await stripe.retrievePaymentIntent(clientSecret);
+      if (pi.error) throw pi.error;
+      setStripeStatus('success');
+    } catch (error) {
+      console.error('Failed to call Stripe API:', error);
+      setStripeStatus('error');
+    }
+  }, []);
+
+  const handleTestBrevo = useCallback(async () => {
+    setBrevoStatus('loading');
+    try {
+      const response = await fetch('/.netlify/functions/brevo');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      await response.json();
+      setBrevoStatus('success');
+    } catch (error) {
+      console.error('Failed to send Brevo email:', error);
+      setBrevoStatus('error');
+    }
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-200 font-sans p-4 sm:p-6 lg:p-8">
@@ -168,15 +214,16 @@ export { handler };`} />
 SUPABASE_URL=your-project-url
 SUPABASE_ANON_KEY=your-public-anon-key
 
-# Google Gemini API
-API_KEY=your-google-api-key
+  # Google APIs (Gemini, Cloud Vision)
+  API_KEY=your-google-api-key
 
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...
 
 # Brevo (formerly Sendinblue) for transactional emails
-BREVO_API_KEY=your-brevo-api-key`} />
+BREVO_API_KEY=your-brevo-api-key
+BREVO_TEST_EMAIL=your-email@example.com`} />
             <p className="text-gray-400 mt-4">In your functions, you can access these with <code className="text-pink-400">process.env.YOUR_VARIABLE_NAME</code>.</p>
           </Card>
           
@@ -269,6 +316,57 @@ insert into notes (title) values ('This is a test note');`} />
                     className="bg-blue-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-blue-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-blue-500"
                   >
                     {visionStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Gemini API Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Gemini API</p>
+                  <p className="font-mono text-xs text-gray-500">/gemini</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={geminiStatus} /></div>
+                  <button
+                    onClick={handleTestGemini}
+                    disabled={geminiStatus === 'loading'}
+                    className="bg-purple-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-purple-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-purple-500"
+                  >
+                    {geminiStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Stripe API Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Stripe API</p>
+                  <p className="font-mono text-xs text-gray-500">/stripe</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={stripeStatus} /></div>
+                  <button
+                    onClick={handleTestStripe}
+                    disabled={stripeStatus === 'loading'}
+                    className="bg-pink-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-pink-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-pink-500"
+                  >
+                    {stripeStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Brevo Email Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Brevo Email</p>
+                  <p className="font-mono text-xs text-gray-500">/brevo</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={brevoStatus} /></div>
+                  <button
+                    onClick={handleTestBrevo}
+                    disabled={brevoStatus === 'loading'}
+                    className="bg-orange-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-orange-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-orange-500"
+                  >
+                    {brevoStatus === 'loading' ? 'Testing...' : 'Test'}
                   </button>
                 </div>
               </div>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ View your app in AI Studio: https://ai.studio/apps/drive/1obfZF7oOAe0Q_QEMBWYn_F
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the required keys in [.env.local](.env.local): `API_KEY` (Google - used for both Gemini and Cloud Vision), `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, `BREVO_API_KEY`, and `BREVO_TEST_EMAIL`
 3. Run the app:
    `npm run dev`
+
+The project includes sample Netlify functions for Ping, Supabase, Cloud Vision, Gemini, Stripe, and Brevo that you can invoke from the UI to verify your environment configuration.

--- a/netlify/functions/brevo.ts
+++ b/netlify/functions/brevo.ts
@@ -1,0 +1,47 @@
+import type { Handler } from "@netlify/functions";
+
+const handler: Handler = async () => {
+  const apiKey = process.env.BREVO_API_KEY;
+  const toEmail = process.env.BREVO_TEST_EMAIL;
+  const fromEmail = process.env.BREVO_SENDER_EMAIL || toEmail;
+
+  if (!apiKey || !toEmail) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing BREVO_API_KEY or BREVO_TEST_EMAIL environment variables" }),
+    };
+  }
+
+  const payload = {
+    sender: { email: fromEmail },
+    to: [{ email: toEmail }],
+    subject: "Test Email from Netlify",
+    htmlContent: "<p>This is a test email sent from a Netlify function.</p>",
+  };
+
+  try {
+    const response = await fetch("https://api.brevo.com/v3/smtp/email", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": apiKey,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: response.status, body: text };
+    }
+
+    const data = await response.json();
+    return { statusCode: 200, body: JSON.stringify(data) };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};
+
+export { handler };

--- a/netlify/functions/gemini.ts
+++ b/netlify/functions/gemini.ts
@@ -1,0 +1,51 @@
+import type { Handler } from "@netlify/functions";
+
+const handler: Handler = async () => {
+  const apiKey = process.env.API_KEY;
+
+  if (!apiKey) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing API_KEY environment variable" }),
+    };
+  }
+
+  const body = {
+    contents: [
+      {
+        parts: [{ text: "Hello" }],
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: response.status, body: text };
+    }
+
+    const data = await response.json();
+    const generatedText = data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ text: generatedText }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};
+
+export { handler };

--- a/netlify/functions/stripe.ts
+++ b/netlify/functions/stripe.ts
@@ -1,0 +1,33 @@
+import type { Handler } from "@netlify/functions";
+import Stripe from "stripe";
+
+const handler: Handler = async () => {
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: "Missing STRIPE_SECRET_KEY environment variable" }),
+    };
+  }
+
+  try {
+    const stripe = new Stripe(secretKey, { apiVersion: undefined });
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: 100,
+      currency: "usd",
+      payment_method_types: ["card"],
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ clientSecret: paymentIntent.client_secret }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: error.message }),
+    };
+  }
+};
+
+export { handler };

--- a/netlify/functions/vision.ts
+++ b/netlify/functions/vision.ts
@@ -5,12 +5,12 @@ const sampleImage =
   "iVBORw0KGgoAAAANSUhEUgAAAMgAAABGCAIAAAAGgExhAAACI0lEQVR4nO3asYriQACH8dmLuKKFaUVs9AGstBGCgpWlpQoWAd/BJ/AhBAvrgKWWFhaSJ7ASRAQ7bQwIYq4Q5LiVDXj353a971fNmJGM8MUE8S0MQwP8bT/+9QbwmggLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAWJ6LBs2/5k+vDQJ2vwn+AbCxJPhnU4HDqdTr1edxzH9/2Ha/b7faPRcByn0Wjs9/s/2CS+oTBKOp3+OHVdd7lchmG42WyKxeJvK2+DVqs1Ho/DMByPx+12O/JEeCVvYdT/sZLJZLlcvk993w+CIJfLFQqF2yu73W61WlmWZdv28Xg0xtwG2Wx2vV6/v7+fz+d8Pr/b7WRXB76cWOSKeDw+n8/v09uD+eVymc1miUTier0uFgvLsj6+MTJZvLAnn7EqlcpkMjHGTKfTwWDwcE2tVvM8zxjjeV61Wn12h/iWom+F9xvcr9Ptdtvr9YIgiMViw+Ewn88bY0qlUrPZ7Pf7t0G323Vd93Q6pVKp0WiUyWSknwRfSnRYwBP4HQsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsShAUJwoIEYUGCsCBBWJAgLEgQFiQICxKEBQnCggRhQYKwIEFYkCAsSBAWJAgLEoQFCcKCBGFBgrAgQViQICxIEBYkCAsSPwElPa4nkCj/vAAAAABJRU5ErkJggg==";
 
 const handler: Handler = async () => {
-  const apiKey = process.env.GOOGLE_VISION_API_KEY;
+  const apiKey = process.env.API_KEY;
 
   if (!apiKey) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: "Missing GOOGLE_VISION_API_KEY environment variable" }),
+      body: JSON.stringify({ error: "Missing API_KEY environment variable" }),
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@netlify/functions": "^2.7.0",
+    "@stripe/stripe-js": "^7.9.0",
     "@supabase/supabase-js": "^2.45.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "stripe": "^18.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,9 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        // Shared Google API key for Gemini and Vision
+        'process.env.API_KEY': JSON.stringify(env.API_KEY),
+        'process.env.STRIPE_PUBLISHABLE_KEY': JSON.stringify(env.STRIPE_PUBLISHABLE_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- Add Stripe Netlify function and frontend Stripe.js test button for PaymentIntent creation
- Add Brevo email Netlify function and UI test button
- Document Stripe and Brevo environment variables and sample functions
- Clarify README instructions for shared Google API key and include Stripe publishable key in Vite config
- Ignore package-lock.json to avoid merge conflicts

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c420b3ad908330a9a88c11b961e4de