### PR TITLE
Add Stripe and Brevo health checks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,8 @@ const App: React.FC = () => {
   const [supabaseStatus, setSupabaseStatus] = useState<Status>('idle');
   const [visionStatus, setVisionStatus] = useState<Status>('idle');
   const [geminiStatus, setGeminiStatus] = useState<Status>('idle');
+  const [stripeStatus, setStripeStatus] = useState<Status>('idle');
+  const [brevoStatus, setBrevoStatus] = useState<Status>('idle');
 
   const handlePing = useCallback(async () => {
     setPingStatus('loading');
@@ -89,6 +91,32 @@ const App: React.FC = () => {
     }
   }, []);
 
+
+  const handleTestStripe = useCallback(async () => {
+    setStripeStatus('loading');
+    try {
+      const response = await fetch('/.netlify/functions/stripe');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      await response.json();
+      setStripeStatus('success');
+    } catch (error) {
+      console.error("Failed to call Stripe API:", error);
+      setStripeStatus('error');
+    }
+  }, []);
+
+  const handleTestBrevo = useCallback(async () => {
+    setBrevoStatus('loading');
+    try {
+      const response = await fetch('/.netlify/functions/brevo');
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      await response.json();
+      setBrevoStatus('success');
+    } catch (error) {
+      console.error("Failed to call Brevo API:", error);
+      setBrevoStatus('error');
+    }
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-200 font-sans p-4 sm:p-6 lg:p-8">
@@ -300,6 +328,40 @@ insert into notes (title) values ('This is a test note');`} />
                     className="bg-purple-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-purple-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-purple-500"
                   >
                     {geminiStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Stripe API Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Stripe API</p>
+                  <p className="font-mono text-xs text-gray-500">/stripe</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={stripeStatus} /></div>
+                  <button
+                    onClick={handleTestStripe}
+                    disabled={stripeStatus === 'loading'}
+                    className="bg-red-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-red-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-red-500"
+                  >
+                    {stripeStatus === 'loading' ? 'Testing...' : 'Test'}
+                  </button>
+                </div>
+              </div>
+              {/* Brevo API Test */}
+              <div className="flex items-center justify-between bg-gray-900/70 p-3 rounded-lg border border-gray-700">
+                <div>
+                  <p className="font-semibold text-gray-300">Brevo API</p>
+                  <p className="font-mono text-xs text-gray-500">/brevo</p>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="w-5 h-5 flex items-center justify-center"><StatusIndicator status={brevoStatus} /></div>
+                  <button
+                    onClick={handleTestBrevo}
+                    disabled={brevoStatus === 'loading'}
+                    className="bg-orange-600 text-white font-semibold py-1.5 px-4 rounded-md text-sm hover:bg-orange-500 transition-colors duration-200 disabled:bg-gray-600 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-900 focus:ring-orange-500"
+                  >
+                    {brevoStatus === 'loading' ? 'Testing...' : 'Test'}
                   </button>
                 </div>
               </div>

--- a/netlify/functions/brevo.ts
+++ b/netlify/functions/brevo.ts
@@ -1,0 +1,55 @@
+import SibApiV3Sdk from 'sib-api-v3-sdk';
+import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions';
+
+/**
+ * A serverless function to verify Brevo connectivity by sending a test email.
+ */
+const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+  const { BREVO_API_KEY, BREVO_TEST_TO_EMAIL, BREVO_TEST_FROM_EMAIL } = process.env;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  if (!BREVO_API_KEY) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Brevo environment variable (BREVO_API_KEY) is not set in the Netlify dashboard.' }),
+      headers,
+    };
+  }
+
+  try {
+    const client = SibApiV3Sdk.ApiClient.instance;
+    client.authentications['api-key'].apiKey = BREVO_API_KEY;
+
+    const emailApi = new SibApiV3Sdk.TransactionalEmailsApi();
+    const sendSmtpEmail = {
+      sender: { email: BREVO_TEST_FROM_EMAIL || 'sender@example.com', name: 'Brevo Test' },
+      to: [{ email: BREVO_TEST_TO_EMAIL || 'recipient@example.com', name: 'Brevo Recipient' }],
+      subject: 'Brevo test',
+      textContent: 'Checking Brevo connection'
+    };
+
+    await emailApi.sendTransacEmail(sendSmtpEmail);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: 'Email sent via Brevo.' }),
+      headers,
+    };
+  } catch (error: any) {
+    console.error('Brevo connection error:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: 'Failed to send email via Brevo.',
+        details: error.message || 'An unknown error occurred.',
+      }),
+      headers,
+    };
+  }
+};
+
+export { handler };

--- a/netlify/functions/stripe.ts
+++ b/netlify/functions/stripe.ts
@@ -1,0 +1,44 @@
+import Stripe from 'stripe';
+import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions';
+
+/**
+ * A serverless function to verify Stripe connectivity by retrieving account balance.
+ */
+const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+  const { STRIPE_SECRET_KEY } = process.env;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  if (!STRIPE_SECRET_KEY) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Stripe environment variable (STRIPE_SECRET_KEY) is not set in the Netlify dashboard.' }),
+      headers,
+    };
+  }
+
+  try {
+    const stripe = new Stripe(STRIPE_SECRET_KEY);
+    const balance = await stripe.balance.retrieve();
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: 'Successfully connected to Stripe.', balance }),
+      headers,
+    };
+  } catch (error: any) {
+    console.error('Stripe connection error:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: 'Failed to connect to Stripe.',
+        details: error.message || 'An unknown error occurred.',
+      }),
+      headers,
+    };
+  }
+};
+
+export { handler };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "@netlify/functions": "^2.7.0",
     "@supabase/supabase-js": "^2.45.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sib-api-v3-sdk": "^8.5.0",
+    "stripe": "^18.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",


### PR DESCRIPTION
## Summary
- add Netlify functions to verify Stripe balance retrieval and Brevo email sending
- expose Stripe and Brevo checks in health check UI
- install Stripe and Brevo SDK dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4642a1830833085408c4f5070205e