### PR TITLE
Ensure fresh file analysis before saving results

### DIFF
--- a/components/AnalysisOverlay.tsx
+++ b/components/AnalysisOverlay.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AnalysisOverlayProps {
+  visible: boolean;
+}
+
+const AnalysisOverlay: React.FC<AnalysisOverlayProps> = ({ visible }) => {
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80 dark:bg-slate-900/80">
+      <div className="w-16 h-16 border-4 border-[var(--accent-color)] border-t-transparent rounded-full animate-spin"></div>
+      <p className="mt-4 text-[var(--accent-color)] text-lg font-medium text-center px-4">
+        Analyzing your documents… This may take a few moments.
+      </p>
+    </div>
+  );
+};
+
+export default AnalysisOverlay;

--- a/netlify/functions/quote-request.ts
+++ b/netlify/functions/quote-request.ts
@@ -50,19 +50,6 @@ const handler: Handler = async (event) => {
 
     if (uploadError) throw uploadError;
 
-    const { data: inserted, error: insertError } = await supabase
-      .from('orders')
-      .insert({
-        name,
-        email,
-        phone,
-        data: { sourceLang, targetLang, filePath: path },
-      })
-      .select('id')
-      .single();
-
-    if (insertError) throw insertError;
-
     // Google Vision OCR
     const visionBody = {
       requests: [
@@ -120,6 +107,19 @@ const handler: Handler = async (event) => {
     const geminiData = await geminiResp.json();
     const analysis =
       geminiData.candidates?.[0]?.content?.parts?.[0]?.text || '';
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('orders')
+      .insert({
+        name,
+        email,
+        phone,
+        data: { sourceLang, targetLang, filePath: path, ocrText, analysis },
+      })
+      .select('id')
+      .single();
+
+    if (insertError) throw insertError;
 
     return {
       statusCode: 200,


### PR DESCRIPTION
## Summary
- Send uploaded files to the `quote-request` API for real-time Vision and Gemini analysis before calculating quotes and saving results.
- Display a branded overlay spinner while documents are being analyzed.
- Persist OCR text and Gemini analysis to Supabase only after both APIs complete.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c4c7a05b1c8330a3b28bbdc7d5d312