### PR TITLE
Ensure fresh file analysis before saving results

### DIFF
--- a/components/AnalysisOverlay.tsx
+++ b/components/AnalysisOverlay.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AnalysisOverlayProps {
+  visible: boolean;
+}
+
+const AnalysisOverlay: React.FC<AnalysisOverlayProps> = ({ visible }) => {
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80 dark:bg-slate-900/80">
+      <div className="w-16 h-16 border-4 border-[var(--accent-color)] border-t-transparent rounded-full animate-spin"></div>
+      <p className="mt-4 text-[var(--accent-color)] text-lg font-medium text-center px-4">
+        Analyzing your documents… This may take a few moments.
+      </p>
+    </div>
+  );
+};
+
+export default AnalysisOverlay;

--- a/components/QuoteScreen.tsx
+++ b/components/QuoteScreen.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QuoteResult } from '../helpers/quoteTypes';
+
+interface QuoteScreenProps {
+  result: QuoteResult;
+  onPay: () => void;
+}
+
+const QuoteScreen: React.FC<QuoteScreenProps> = ({ result, onPay }) => {
+  return (
+    <div className="space-y-4" aria-label="Quote details">
+      <h2 className="text-xl font-semibold">Quote ID: {result.quoteId}</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm" role="table">
+          <thead>
+            <tr className="bg-gray-100 dark:bg-slate-700">
+              <th className="p-2 text-left">File</th>
+              <th className="p-2 text-left">Page</th>
+              <th className="p-2 text-left">Wordcount</th>
+              <th className="p-2 text-left">Complexity</th>
+              <th className="p-2 text-left">Multiplier</th>
+              <th className="p-2 text-left">PPWC</th>
+              <th className="p-2 text-left">Billable Pages</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.files.map(f => (
+              <React.Fragment key={f.fileId}>
+                <tr className="bg-gray-50 dark:bg-slate-700 font-semibold">
+                  <td className="p-2" colSpan={7}>{f.filename}</td>
+                </tr>
+                {f.pages.map(p => (
+                  <tr key={p.pageNumber} className="border-b">
+                    <td className="p-2"></td>
+                    <td className="p-2">{p.pageNumber}</td>
+                    <td className="p-2">{p.wordCount}</td>
+                    <td className="p-2">{p.complexity}</td>
+                    <td className="p-2">{p.complexityMultiplier.toFixed(2)}</td>
+                    <td className="p-2">{p.ppwc.toFixed(2)}</td>
+                    <td className="p-2">{p.billablePages.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="p-4 border rounded grid grid-cols-1 md:grid-cols-2 gap-2">
+        <p><strong>Per-page rate:</strong> ${result.perPageRate.toFixed(2)}</p>
+        <p><strong>Total billable pages:</strong> {result.totalBillablePages.toFixed(2)}</p>
+        <p><strong>Certification:</strong> {result.certType} (${result.certPrice.toFixed(2)})</p>
+        <p className="text-lg font-semibold">Final Total: ${result.quoteTotal.toFixed(2)}</p>
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Billable pages are calculated from word count and complexity. Minimum charge of one page per quote.
+      </p>
+      <button
+        onClick={onPay}
+        className="w-full md:w-auto bg-[var(--accent-color)] hover:bg-[var(--accent-color-dark)] text-white py-2 px-6 rounded"
+      >
+        Accept and Pay
+      </button>
+    </div>
+  );
+};
+
+export default QuoteScreen;
+

--- a/helpers/quoteTypes.ts
+++ b/helpers/quoteTypes.ts
@@ -1,0 +1,7 @@
+import { FileAnalysis, QuoteTotals } from './quoteCalculator';
+
+export interface QuoteResult extends QuoteTotals {
+  quoteId: string;
+  files: FileAnalysis[];
+}
+


### PR DESCRIPTION
## Summary
- Use `DOCUMENT_TEXT_DETECTION` for PDFs and request Gemini for structured language/complexity details before inserting orders
- Surface backend failures to the user and apply returned complexity instead of a default

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c7a05b1c8330a3b28bbdc7d5d312