### PR TITLE
Ensure fresh file analysis before saving results

### DIFF
--- a/components/AnalysisOverlay.tsx
+++ b/components/AnalysisOverlay.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState, useRef } from 'react';
+
+type JobEvent = { ts: string; step: string; message: string; progress?: number };
+type Job = { status: string; error?: string };
+
+export default function AnalysisOverlay({ jobId }: { jobId?: string }) {
+  const [events, setEvents] = useState<JobEvent[]>([]);
+  const [job, setJob] = useState<Job | null>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const timer = setInterval(async () => {
+      try {
+        const res = await fetch(`/.netlify/functions/quote-status?jobId=${jobId}`);
+        const { job, events } = await res.json();
+        setJob(job);
+        setEvents(events || []);
+      } catch {
+        setEvents(prev => [
+          ...prev,
+          {
+            ts: new Date().toISOString(),
+            step: 'client',
+            message: 'Lost connection to status endpoint… retrying'
+          }
+        ]);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [jobId]);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [events]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-white/80 dark:bg-slate-900/80">
+      <div className="w-16 h-16 border-4 border-[var(--accent-color)] border-t-transparent rounded-full animate-spin" aria-live="polite"></div>
+      <p className="mt-4 text-[var(--accent-color)] text-lg font-medium text-center px-4">
+        We’re analyzing your files. This usually takes a moment.
+      </p>
+      {jobId && (
+        <div className="mt-4 w-full max-w-md overflow-hidden rounded-lg shadow bg-white dark:bg-slate-800" role="log" aria-live="polite">
+          <div className="max-h-56 overflow-auto divide-y divide-gray-200 dark:divide-slate-700">
+            {events.map((e, i) => (
+              <div key={i} className="px-4 py-2 text-sm grid grid-cols-6 gap-2 items-center">
+                <span className="col-span-2 opacity-70 font-mono text-xs">{new Date(e.ts).toLocaleTimeString()}</span>
+                <span className="col-span-2 font-semibold uppercase tracking-wide">{e.step}</span>
+                <span className="col-span-2">{e.message}</span>
+                {typeof e.progress === 'number' && (
+                  <progress max={100} value={e.progress} className="col-span-6 w-full" />
+                )}
+              </div>
+            ))}
+            {job?.status === 'failed' && (
+              <div className="px-4 py-2 text-sm text-red-500">⚠️ {job.error || 'Unexpected error'}</div>
+            )}
+            {job?.status === 'succeeded' && (
+              <div className="px-4 py-2 text-sm text-green-600">✅ Analysis complete. Building your quote…</div>
+            )}
+            <div ref={endRef} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/QuoteRequestForm.tsx
+++ b/components/QuoteRequestForm.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useRef } from 'react';
-import { analyzeFiles, calculateQuote, FileAnalysis, QuoteTotals } from '../helpers/quoteCalculator';
+import AnalysisOverlay from './AnalysisOverlay';
+import { calculateQuote, FileAnalysis, appSettings } from '../helpers/quoteCalculator';
+import QuoteScreen from './QuoteScreen';
+import { QuoteResult } from '../helpers/quoteTypes';
 
 interface FormState {
   customerName: string;
@@ -21,17 +24,13 @@ const initialForm: FormState = {
   uploadedFiles: [],
 };
 
-interface Result extends QuoteTotals {
-  quoteId: string;
-  files: FileAnalysis[];
-}
-
 const QuoteRequestForm: React.FC = () => {
   const [form, setForm] = useState<FormState>(initialForm);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<Result | null>(null);
+  const [result, setResult] = useState<QuoteResult | null>(null);
   const [quoteCounter, setQuoteCounter] = useState(() => Math.floor(Math.random() * 90000));
+  const [jobId, setJobId] = useState<string | null>(null);
   const fileInput = useRef<HTMLInputElement | null>(null);
 
   const validate = () => {
@@ -74,15 +73,81 @@ const QuoteRequestForm: React.FC = () => {
     setForm(prev => ({ ...prev, uploadedFiles: prev.uploadedFiles.filter((_, i) => i !== index) }));
   };
 
+  const complexityMap: Record<'Easy' | 'Medium' | 'Hard', number> = {
+    Easy: 1.0,
+    Medium: 1.1,
+    Hard: 1.2,
+  };
+
+  const fileToBase64 = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        const base64 = result.split(',')[1];
+        resolve(base64);
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setResult(null);
+    setJobId(null);
     if (!validate()) return;
     setLoading(true);
     try {
-      const analyses = await analyzeFiles(form.uploadedFiles);
+      const analyses: FileAnalysis[] = [];
+      for (const file of form.uploadedFiles) {
+        const base64 = await fileToBase64(file);
+        const response = await fetch('/.netlify/functions/quote-request', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: form.customerName,
+            email: form.customerEmail,
+            phone: form.customerPhone,
+            sourceLang: form.sourceLanguage,
+            targetLang: form.targetLanguage,
+            fileName: file.name,
+            fileType: file.type,
+            fileBase64: base64,
+          }),
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text);
+        }
+
+        const data = await response.json();
+        if (data.jobId) setJobId(data.jobId);
+        const wordCount = data.ocrText ? data.ocrText.trim().split(/\s+/).length : 0;
+        const complexity: 'Easy' | 'Medium' | 'Hard' =
+          data.complexity || 'Medium';
+        const complexityMultiplier = complexityMap[complexity];
+        const ppwc = wordCount * complexityMultiplier;
+        const billablePages = Math.ceil((ppwc / appSettings.wordsPerPage) * 10) / 10;
+        analyses.push({
+          fileId: data.id?.toString() || file.name,
+          filename: file.name,
+          pageCount: 1,
+          pages: [
+            {
+              pageNumber: 1,
+              wordCount,
+              complexity,
+              complexityMultiplier,
+              ppwc,
+              billablePages,
+            },
+          ],
+        });
+      }
+
       const quoteTotals = calculateQuote(analyses, form);
-      const id = `CS${(quoteCounter + 1).toString().padStart(5,'0')}`;
+      const id = `CS${(quoteCounter + 1).toString().padStart(5, '0')}`;
       setQuoteCounter(prev => prev + 1);
       setResult({ quoteId: id, files: analyses, ...quoteTotals });
     } finally {
@@ -90,58 +155,66 @@ const QuoteRequestForm: React.FC = () => {
     }
   };
 
+  const handlePay = () => {
+    if (!result) return;
+    // Assumes existing payment endpoint accepts quoteId and handles checkout.
+    window.location.href = `/.netlify/functions/stripe-checkout?quoteId=${result.quoteId}`;
+  };
+
   return (
     <div className="max-w-5xl mx-auto p-4">
-      <form onSubmit={handleSubmit} className="space-y-6" aria-label="Quote request form">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="customerName" className="block text-sm font-medium">Name<span className="text-[var(--error-color)]">*</span></label>
-            <input id="customerName" name="customerName" value={form.customerName} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
-            {errors.customerName && <p className="text-[var(--error-color)] text-sm">{errors.customerName}</p>}
+      {loading && <AnalysisOverlay jobId={jobId || undefined} />}
+      {!result ? (
+        <form onSubmit={handleSubmit} className="space-y-6" aria-label="Quote request form">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="customerName" className="block text-sm font-medium">Name<span className="text-[var(--error-color)]">*</span></label>
+              <input id="customerName" name="customerName" value={form.customerName} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
+              {errors.customerName && <p className="text-[var(--error-color)] text-sm">{errors.customerName}</p>}
+            </div>
+            <div>
+              <label htmlFor="customerEmail" className="block text-sm font-medium">Email<span className="text-[var(--error-color)]">*</span></label>
+              <input id="customerEmail" type="email" name="customerEmail" value={form.customerEmail} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
+              {errors.customerEmail && <p className="text-[var(--error-color)] text-sm">{errors.customerEmail}</p>}
+            </div>
+            <div>
+              <label htmlFor="customerPhone" className="block text-sm font-medium">Phone</label>
+              <input id="customerPhone" name="customerPhone" value={form.customerPhone} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
+            </div>
+            <div>
+              <label htmlFor="intendedUse" className="block text-sm font-medium">Intended Use<span className="text-[var(--error-color)]">*</span></label>
+              <select id="intendedUse" name="intendedUse" value={form.intendedUse} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
+                <option value="">Select...</option>
+                <option value="USCIS">USCIS</option>
+                <option value="Court">Court</option>
+              </select>
+              {errors.intendedUse && <p className="text-[var(--error-color)] text-sm">{errors.intendedUse}</p>}
+            </div>
+            <div>
+              <label htmlFor="sourceLanguage" className="block text-sm font-medium">Source Language<span className="text-[var(--error-color)]">*</span></label>
+              <select id="sourceLanguage" name="sourceLanguage" value={form.sourceLanguage} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
+                <option value="">Select...</option>
+                <option>English</option>
+                <option>Spanish</option>
+                <option>French</option>
+                <option>German</option>
+                <option>Japanese</option>
+              </select>
+              {errors.sourceLanguage && <p className="text-[var(--error-color)] text-sm">{errors.sourceLanguage}</p>}
+            </div>
+            <div>
+              <label htmlFor="targetLanguage" className="block text-sm font-medium">Target Language<span className="text-[var(--error-color)]">*</span></label>
+              <select id="targetLanguage" name="targetLanguage" value={form.targetLanguage} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
+                <option value="">Select...</option>
+                <option>English</option>
+                <option>Spanish</option>
+                <option>French</option>
+                <option>German</option>
+                <option>Japanese</option>
+              </select>
+              {errors.targetLanguage && <p className="text-[var(--error-color)] text-sm">{errors.targetLanguage}</p>}
+            </div>
           </div>
-          <div>
-            <label htmlFor="customerEmail" className="block text-sm font-medium">Email<span className="text-[var(--error-color)]">*</span></label>
-            <input id="customerEmail" type="email" name="customerEmail" value={form.customerEmail} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
-            {errors.customerEmail && <p className="text-[var(--error-color)] text-sm">{errors.customerEmail}</p>}
-          </div>
-          <div>
-            <label htmlFor="customerPhone" className="block text-sm font-medium">Phone</label>
-            <input id="customerPhone" name="customerPhone" value={form.customerPhone} onChange={handleChange} className="mt-1 w-full p-2 border rounded" />
-          </div>
-          <div>
-            <label htmlFor="intendedUse" className="block text-sm font-medium">Intended Use<span className="text-[var(--error-color)]">*</span></label>
-            <select id="intendedUse" name="intendedUse" value={form.intendedUse} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
-              <option value="">Select...</option>
-              <option value="USCIS">USCIS</option>
-              <option value="Court">Court</option>
-            </select>
-            {errors.intendedUse && <p className="text-[var(--error-color)] text-sm">{errors.intendedUse}</p>}
-          </div>
-          <div>
-            <label htmlFor="sourceLanguage" className="block text-sm font-medium">Source Language<span className="text-[var(--error-color)]">*</span></label>
-            <select id="sourceLanguage" name="sourceLanguage" value={form.sourceLanguage} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
-              <option value="">Select...</option>
-              <option>English</option>
-              <option>Spanish</option>
-              <option>French</option>
-              <option>German</option>
-              <option>Japanese</option>
-            </select>
-            {errors.sourceLanguage && <p className="text-[var(--error-color)] text-sm">{errors.sourceLanguage}</p>}
-          </div>
-          <div>
-            <label htmlFor="targetLanguage" className="block text-sm font-medium">Target Language<span className="text-[var(--error-color)]">*</span></label>
-            <select id="targetLanguage" name="targetLanguage" value={form.targetLanguage} onChange={handleChange} className="mt-1 w-full p-2 border rounded">
-              <option value="">Select...</option>
-              <option>English</option>
-              <option>Spanish</option>
-              <option>French</option>
-              <option>German</option>
-              <option>Japanese</option>
-            </select>
-            {errors.targetLanguage && <p className="text-[var(--error-color)] text-sm">{errors.targetLanguage}</p>}
-          </div>
-        </div>
 
         <div
           className="border-2 border-dashed rounded p-4 text-center" onDragOver={e => e.preventDefault()} onDrop={handleDrop}
@@ -160,60 +233,15 @@ const QuoteRequestForm: React.FC = () => {
         </div>
 
         <button type="submit" className="w-full md:w-auto bg-[var(--accent-color)] hover:bg-[var(--accent-color-dark)] text-white py-2 px-6 rounded">
-          {loading ? 'Calculating...' : 'Get Quote'}
+          {loading ? 'Analyzing...' : 'Get Quote'}
         </button>
       </form>
-
-      {result && (
-        <div className="mt-8 space-y-4">
-          <h2 className="text-xl font-semibold">Quote ID: {result.quoteId}</h2>
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm" role="table">
-              <thead>
-                <tr className="bg-gray-100 dark:bg-slate-700">
-                  <th className="p-2 text-left">File</th>
-                  <th className="p-2 text-left">Page</th>
-                  <th className="p-2 text-left">Wordcount</th>
-                  <th className="p-2 text-left">Complexity</th>
-                  <th className="p-2 text-left">Multiplier</th>
-                  <th className="p-2 text-left">PPWC</th>
-                  <th className="p-2 text-left">Billable Pages</th>
-                </tr>
-              </thead>
-              <tbody>
-                {result.files.map(f => (
-                  <React.Fragment key={f.fileId}>
-                    <tr className="bg-gray-50 dark:bg-slate-700 font-semibold">
-                      <td className="p-2" colSpan={7}>{f.filename}</td>
-                    </tr>
-                    {f.pages.map(p => (
-                      <tr key={p.pageNumber} className="border-b">
-                        <td className="p-2"></td>
-                        <td className="p-2">{p.pageNumber}</td>
-                        <td className="p-2">{p.wordCount}</td>
-                        <td className="p-2">{p.complexity}</td>
-                        <td className="p-2">{p.complexityMultiplier.toFixed(2)}</td>
-                        <td className="p-2">{p.ppwc.toFixed(2)}</td>
-                        <td className="p-2">{p.billablePages.toFixed(2)}</td>
-                      </tr>
-                    ))}
-                  </React.Fragment>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div className="p-4 border rounded grid grid-cols-1 md:grid-cols-2 gap-2">
-            <p><strong>Per-page rate:</strong> ${result.perPageRate.toFixed(2)}</p>
-            <p><strong>Total billable pages:</strong> {result.totalBillablePages.toFixed(2)}</p>
-            <p><strong>Certification:</strong> {result.certType} (${result.certPrice.toFixed(2)})</p>
-            <p className="text-lg font-semibold">Final Total: ${result.quoteTotal.toFixed(2)}</p>
-          </div>
-          <p className="text-sm text-gray-600 dark:text-gray-300">Billable pages are calculated from word count and complexity. Minimum charge of one page per quote.</p>
-        </div>
+      ) : (
+        <QuoteScreen result={result} onPay={handlePay} />
       )}
     </div>
   );
 };
 
 export default QuoteRequestForm;
+

--- a/components/QuoteScreen.tsx
+++ b/components/QuoteScreen.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QuoteResult } from '../helpers/quoteTypes';
+
+interface QuoteScreenProps {
+  result: QuoteResult;
+  onPay: () => void;
+}
+
+const QuoteScreen: React.FC<QuoteScreenProps> = ({ result, onPay }) => {
+  return (
+    <div className="space-y-4" aria-label="Quote details">
+      <h2 className="text-xl font-semibold">Quote ID: {result.quoteId}</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm" role="table">
+          <thead>
+            <tr className="bg-gray-100 dark:bg-slate-700">
+              <th className="p-2 text-left">File</th>
+              <th className="p-2 text-left">Page</th>
+              <th className="p-2 text-left">Wordcount</th>
+              <th className="p-2 text-left">Complexity</th>
+              <th className="p-2 text-left">Multiplier</th>
+              <th className="p-2 text-left">PPWC</th>
+              <th className="p-2 text-left">Billable Pages</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.files.map(f => (
+              <React.Fragment key={f.fileId}>
+                <tr className="bg-gray-50 dark:bg-slate-700 font-semibold">
+                  <td className="p-2" colSpan={7}>{f.filename}</td>
+                </tr>
+                {f.pages.map(p => (
+                  <tr key={p.pageNumber} className="border-b">
+                    <td className="p-2"></td>
+                    <td className="p-2">{p.pageNumber}</td>
+                    <td className="p-2">{p.wordCount}</td>
+                    <td className="p-2">{p.complexity}</td>
+                    <td className="p-2">{p.complexityMultiplier.toFixed(2)}</td>
+                    <td className="p-2">{p.ppwc.toFixed(2)}</td>
+                    <td className="p-2">{p.billablePages.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="p-4 border rounded grid grid-cols-1 md:grid-cols-2 gap-2">
+        <p><strong>Per-page rate:</strong> ${result.perPageRate.toFixed(2)}</p>
+        <p><strong>Total billable pages:</strong> {result.totalBillablePages.toFixed(2)}</p>
+        <p><strong>Certification:</strong> {result.certType} (${result.certPrice.toFixed(2)})</p>
+        <p className="text-lg font-semibold">Final Total: ${result.quoteTotal.toFixed(2)}</p>
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        Billable pages are calculated from word count and complexity. Minimum charge of one page per quote.
+      </p>
+      <button
+        onClick={onPay}
+        className="w-full md:w-auto bg-[var(--accent-color)] hover:bg-[var(--accent-color-dark)] text-white py-2 px-6 rounded"
+      >
+        Accept and Pay
+      </button>
+    </div>
+  );
+};
+
+export default QuoteScreen;
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -102,3 +102,26 @@ CREATE TABLE AppSettings (
 -- INSERT INTO AppSettings (settingKey, settingValue) VALUES ('wordsPerPage','240');
 -- UPDATE AppSettings SET settingValue='70' WHERE settingKey='baseRate';
 -- SELECT settingValue FROM AppSettings WHERE settingKey='baseRate';
+
+-- Table: quote_jobs
+create table if not exists quote_jobs (
+  job_id uuid primary key default gen_random_uuid(),
+  quote_id text,
+  status text not null default 'queued', -- queued | running | succeeded | failed
+  error text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Table: quote_job_events
+create table if not exists quote_job_events (
+  id bigserial primary key,
+  job_id uuid references quote_jobs(job_id) on delete cascade,
+  ts timestamptz default now(),
+  step text,
+  message text,
+  progress int
+);
+
+create index if not exists quote_job_events_jobid_idx
+  on quote_job_events(job_id, ts);

--- a/helpers/quoteTypes.ts
+++ b/helpers/quoteTypes.ts
@@ -1,0 +1,7 @@
+import { FileAnalysis, QuoteTotals } from './quoteCalculator';
+
+export interface QuoteResult extends QuoteTotals {
+  quoteId: string;
+  files: FileAnalysis[];
+}
+

--- a/netlify/functions/_progress.ts
+++ b/netlify/functions/_progress.ts
@@ -1,0 +1,31 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE! // server key only
+);
+
+export async function initJob(quoteId?: string) {
+  const { data, error } = await supabase
+    .from('quote_jobs')
+    .insert({ quote_id: quoteId, status: 'running' })
+    .select('job_id')
+    .single();
+  if (error) throw error;
+  return data.job_id as string;
+}
+
+export async function logEvent(jobId: string, step: string, message: string, progress?: number) {
+  await supabase.from('quote_job_events').insert({
+    job_id: jobId,
+    step,
+    message,
+    progress
+  });
+}
+
+export async function endJob(jobId: string, status: 'succeeded' | 'failed', error?: string) {
+  await supabase.from('quote_jobs')
+    .update({ status, error })
+    .eq('job_id', jobId);
+}

--- a/netlify/functions/quote-status.ts
+++ b/netlify/functions/quote-status.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_ANON_KEY! // safe in serverless function
+);
+
+export async function handler(event: any) {
+  const jobId = event.queryStringParameters?.jobId;
+  if (!jobId) return { statusCode: 400, body: 'Missing jobId' };
+
+  const { data: job } = await supabase
+    .from('quote_jobs')
+    .select('*')
+    .eq('job_id', jobId)
+    .single();
+
+  const { data: events } = await supabase
+    .from('quote_job_events')
+    .select('*')
+    .eq('job_id', jobId)
+    .order('ts', { ascending: true });
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ job, events })
+  };
+}


### PR DESCRIPTION
## Summary
- Use `DOCUMENT_TEXT_DETECTION` for PDFs and request Gemini for structured language/complexity details before inserting orders
- Surface backend failures to the user and apply returned complexity instead of a default
- Track quote-request jobs with Supabase tables, log each backend step, and poll progress from the client
- Show a live log panel under the existing analysis spinner

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c7a05b1c8330a3b28bbdc7d5d312