### PR TITLE
Add sequential quote ID generator

### DIFF
--- a/components/QuoteRequestForm.tsx
+++ b/components/QuoteRequestForm.tsx
@@ -32,7 +32,6 @@ const QuoteRequestForm: React.FC = () => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<Result | null>(null);
-  const [quoteCounter, setQuoteCounter] = useState(() => Math.floor(Math.random() * 90000));
   const fileInput = useRef<HTMLInputElement | null>(null);
 
   const validate = () => {
@@ -141,9 +140,21 @@ const QuoteRequestForm: React.FC = () => {
       }
 
       const quoteTotals = calculateQuote(analyses, form);
-      const id = `CS${(quoteCounter + 1).toString().padStart(5, '0')}`;
-      setQuoteCounter(prev => prev + 1);
-      setResult({ quoteId: id, files: analyses, ...quoteTotals });
+      const resp = await fetch('/.netlify/functions/create-quote', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          customerName: form.customerName,
+          customerEmail: form.customerEmail,
+          customerPhone: form.customerPhone,
+          sourceLanguage: form.sourceLanguage,
+          targetLanguage: form.targetLanguage,
+          intendedUse: form.intendedUse,
+          ...quoteTotals,
+        }),
+      });
+      const { quoteId } = await resp.json();
+      setResult({ quoteId, files: analyses, ...quoteTotals });
     } finally {
       setLoading(false);
     }

--- a/netlify/functions/create-quote.ts
+++ b/netlify/functions/create-quote.ts
@@ -1,0 +1,78 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { generateQuoteId } from './utils/generateQuoteId';
+
+const handler: Handler = async (event) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY } = process.env;
+  const supabaseKey = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
+  if (!SUPABASE_URL || !supabaseKey) {
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Missing environment variables' }) };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const {
+      customerName,
+      customerEmail,
+      customerPhone,
+      sourceLanguage,
+      targetLanguage,
+      intendedUse,
+      perPageRate,
+      totalBillablePages,
+      certType,
+      certPrice,
+      quoteTotal,
+    } = body;
+
+    if (
+      !customerName ||
+      !customerEmail ||
+      !sourceLanguage ||
+      !targetLanguage ||
+      !intendedUse ||
+      typeof perPageRate !== 'number' ||
+      typeof totalBillablePages !== 'number' ||
+      typeof certType !== 'string' ||
+      typeof certPrice !== 'number' ||
+      typeof quoteTotal !== 'number'
+    ) {
+      return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing required fields' }) };
+    }
+
+    const supabase = createClient(SUPABASE_URL, supabaseKey);
+    const quoteId = await generateQuoteId(supabase);
+
+    const { error } = await supabase.from('Quotes').insert({
+      quoteId,
+      customerName,
+      customerEmail,
+      customerPhone,
+      sourceLanguage,
+      targetLanguage,
+      intendedUse,
+      perPageRate,
+      totalBillablePages,
+      certType,
+      certPrice,
+      quoteTotal,
+    });
+
+    if (error) throw error;
+
+    return { statusCode: 200, headers, body: JSON.stringify({ quoteId }) };
+  } catch (err: any) {
+    return { statusCode: 500, headers, body: JSON.stringify({ error: err.message || 'Unknown error' }) };
+  }
+};
+
+export { handler };

--- a/netlify/functions/utils/generateQuoteId.ts
+++ b/netlify/functions/utils/generateQuoteId.ts
@@ -1,0 +1,23 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Generate the next sequential quote ID with a CS prefix.
+ * Example: CS00001, CS00002, ...
+ */
+export async function generateQuoteId(supabase: SupabaseClient): Promise<string> {
+  const { data, error } = await supabase
+    .from('Quotes')
+    .select('quoteId')
+    .order('quoteId', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  const lastId = data?.quoteId as string | undefined;
+  const numeric = lastId ? parseInt(lastId.replace(/^CS/, ''), 10) : 0;
+  const next = numeric + 1;
+  return `CS${next.toString().padStart(5, '0')}`;
+}


### PR DESCRIPTION
## Summary
- add `generateQuoteId` utility to create sequential IDs for quotes
- create `create-quote` function to insert quotes using new IDs
- fetch server-generated quote IDs in `QuoteRequestForm`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4f417f483308d6414980f26c91a