### PR TITLE
Add quote-start function and enforce Supabase service role

### DIFF
--- a/netlify/functions/quote-request.ts
+++ b/netlify/functions/quote-request.ts
@@ -11,11 +11,9 @@ const handler: Handler = async (event) => {
     return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY, API_KEY } = process.env;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE, API_KEY } = process.env;
 
-  const supabaseKey = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
-
-  if (!SUPABASE_URL || !supabaseKey || !API_KEY) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE || !API_KEY) {
     return {
       statusCode: 500,
       headers,
@@ -40,7 +38,7 @@ const handler: Handler = async (event) => {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing required fields' }) };
     }
 
-    const supabase = createClient(SUPABASE_URL, supabaseKey);
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
     const buffer = Buffer.from(fileBase64, 'base64');
     const path = `orders/${Date.now()}-${fileName}`;

--- a/netlify/functions/quote-start.ts
+++ b/netlify/functions/quote-start.ts
@@ -1,0 +1,94 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+
+const handler: Handler = async (event) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Missing environment variables' }),
+    };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const {
+      name,
+      email,
+      phone,
+      sourceLang,
+      targetLang,
+      fileName,
+      fileType,
+      fileBase64,
+    } = body;
+
+    if (!name || !email || !sourceLang || !targetLang || !fileName || !fileType || !fileBase64) {
+      return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing required fields' }) };
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+
+    const buffer = Buffer.from(fileBase64, 'base64');
+    const path = `orders/${Date.now()}-${fileName}`;
+    const { error: uploadError } = await supabase.storage
+      .from('orders')
+      .upload(path, buffer, { contentType: fileType });
+
+    if (uploadError) throw uploadError;
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('orders')
+      .insert({
+        name,
+        email,
+        phone,
+        data: { sourceLang, targetLang, filePath: path },
+      })
+      .select('id')
+      .single();
+
+    if (insertError) throw insertError;
+
+    const host = event.headers['x-forwarded-host'] || event.headers['host'];
+    const proto = event.headers['x-forwarded-proto'] || 'https';
+    const url = new URL('/.netlify/functions/quote-process-background', `${proto}://${host}`);
+
+    const resp = await fetch(url.toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: inserted.id }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text);
+    }
+
+    return {
+      statusCode: 202,
+      headers,
+      body: JSON.stringify({ id: inserted.id }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: error.message || 'Unknown error' }),
+    };
+  }
+};
+
+export { handler };
+

--- a/netlify/functions/supabase.ts
+++ b/netlify/functions/supabase.ts
@@ -6,15 +6,14 @@ import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
  * It fetches the top 1 record from a 'notes' table.
  */
 const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY } = process.env;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
 
   const headers = {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*', // Allow requests from any origin
   };
 
-  const supabaseKey = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
-  if (!SUPABASE_URL || !supabaseKey) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
     return {
       statusCode: 500,
       body: JSON.stringify({ error: 'Supabase environment variables are not set in the Netlify dashboard.' }),
@@ -23,7 +22,7 @@ const handler: Handler = async (event: HandlerEvent, context: HandlerContext) =>
   }
 
   try {
-    const supabase = createClient(SUPABASE_URL, supabaseKey);
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
     // Perform a simple query to test the connection and credentials
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add `quote-start` Netlify function to upload files and call background processor with absolute URL
- require `SUPABASE_SERVICE_ROLE` for Supabase access, dropping anon key fallback

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4de08288330a94425e8fe87777e