### PR TITLE
Add background quote processing with live job status

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -37,7 +37,7 @@ const App: React.FC = () => {
     <div className="min-h-screen flex flex-col">
       <Header />
       <main className="flex-1">
-        {screen === 'form' && <QuoteRequestForm onJobStart={startJob} />}
+        {screen === 'form' && <QuoteRequestForm onJobStart={startJob} onError={handleError} />}
         {screen === 'waiting' && (
           <QuoteJobStatus jobId={jobId} onComplete={handleComplete} onError={handleError} />
         )}

--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,48 @@
 import React from 'react';
 import QuoteRequestForm from './components/QuoteRequestForm';
+import QuoteJobStatus from './components/QuoteJobStatus';
+import QuoteResults from './components/QuoteResults';
+import QuoteError from './components/QuoteError';
 import Header from './components/Header';
 
 const App: React.FC = () => {
+  const [screen, setScreen] = React.useState<'form' | 'waiting' | 'result' | 'error'>('form');
+  const [jobId, setJobId] = React.useState('');
+  const [result, setResult] = React.useState<any>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const startJob = (id: string) => {
+    setJobId(id);
+    setScreen('waiting');
+  };
+
+  const handleComplete = (res: any) => {
+    setResult(res);
+    setScreen('result');
+  };
+
+  const handleError = (msg: string) => {
+    setError(msg);
+    setScreen('error');
+  };
+
+  const reset = () => {
+    setScreen('form');
+    setJobId('');
+    setResult(null);
+    setError(null);
+  };
+
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
       <main className="flex-1">
-        <QuoteRequestForm />
+        {screen === 'form' && <QuoteRequestForm onJobStart={startJob} />}
+        {screen === 'waiting' && (
+          <QuoteJobStatus jobId={jobId} onComplete={handleComplete} onError={handleError} />
+        )}
+        {screen === 'result' && result && <QuoteResults result={result} onReset={reset} />}
+        {screen === 'error' && error && <QuoteError message={error} onReset={reset} />}
       </main>
       <footer className="text-center py-6 text-sm opacity-70">
         <p>&copy; {new Date().getFullYear()} Certified Translation Agency</p>

--- a/components/QuoteError.tsx
+++ b/components/QuoteError.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface QuoteErrorProps {
+  message: string;
+  onReset: () => void;
+}
+
+const QuoteError: React.FC<QuoteErrorProps> = ({ message, onReset }) => (
+  <div className="max-w-md mx-auto p-4 text-center" role="alert">
+    <h2 className="text-2xl font-semibold mb-4 text-[var(--error-color)]">Something went wrong</h2>
+    <p className="mb-4">{message}</p>
+    <button onClick={onReset} className="px-4 py-2 bg-[var(--accent-color)] text-white rounded">Try Again</button>
+  </div>
+);
+
+export default QuoteError;

--- a/components/QuoteJobStatus.tsx
+++ b/components/QuoteJobStatus.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+
+interface Event {
+  id?: number;
+  ts: string;
+  step: string;
+  message: string;
+  progress: number;
+}
+
+interface QuoteJobStatusProps {
+  jobId: string;
+  onComplete: (result: any) => void;
+  onError: (message: string) => void;
+}
+
+const QuoteJobStatus: React.FC<QuoteJobStatusProps> = ({ jobId, onComplete, onError }) => {
+  const [events, setEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const resp = await fetch(`/.netlify/functions/quote-status?jobId=${jobId}`);
+      const data = await resp.json();
+      setEvents(data.events);
+      if (data.job.status === 'completed') {
+        clearInterval(interval);
+        onComplete(data.result);
+      } else if (data.job.status === 'failed') {
+        clearInterval(interval);
+        onError(data.job.error || 'Job failed');
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [jobId, onComplete, onError]);
+
+  return (
+    <div className="flex flex-col items-center py-10" role="region" aria-live="polite">
+      <div className="w-16 h-16 border-4 border-[var(--accent-color)] border-t-transparent rounded-full animate-spin"></div>
+      <p className="mt-4 text-lg font-medium">We’re analyzing your files…</p>
+      <ul className="mt-6 w-full max-w-md h-64 overflow-auto border rounded p-2 text-sm">
+        {events.map(e => (
+          <li key={`${e.ts}-${e.step}`} className="mb-1">
+            <span className="opacity-60 mr-2">{new Date(e.ts).toLocaleTimeString()}</span>
+            <span className="font-semibold mr-2">{e.step}</span>
+            <span>{e.message}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default QuoteJobStatus;

--- a/components/QuoteResults.tsx
+++ b/components/QuoteResults.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { calculateQuote, FileAnalysis } from '../helpers/quoteCalculator';
+
+interface QuoteResultsProps {
+  result: any;
+  onReset: () => void;
+}
+
+const QuoteResults: React.FC<QuoteResultsProps> = ({ result, onReset }) => {
+  const wordCount = result?.data?.wordCount || 0;
+  const complexity = result?.data?.complexity || 'Medium';
+  const complexityMultiplier = result?.data?.complexityMultiplier || 1;
+  const ppwc = result?.data?.ppwc || 0;
+  const billablePages = result?.data?.billablePages || 0;
+
+  const files: FileAnalysis[] = [
+    {
+      fileId: result.id?.toString() || 'file1',
+      filename: result.data?.filePath?.split('/').pop() || 'file',
+      pageCount: 1,
+      pages: [
+        { pageNumber: 1, wordCount, complexity, complexityMultiplier, ppwc, billablePages },
+      ],
+    },
+  ];
+
+  const totals = calculateQuote(files, {
+    sourceLanguage: result.data?.sourceLang || 'English',
+    targetLanguage: result.data?.targetLang || 'English',
+    intendedUse: result.data?.intendedUse || 'USCIS',
+  });
+
+  return (
+    <div className="max-w-3xl mx-auto p-4" role="region" aria-live="polite">
+      <h2 className="text-2xl font-semibold mb-4">Quote Results</h2>
+      <table className="w-full border mb-4">
+        <thead>
+          <tr className="bg-slate-100 dark:bg-slate-800">
+            <th className="p-2 text-left">File</th>
+            <th className="p-2 text-left">Word Count</th>
+            <th className="p-2 text-left">Complexity</th>
+            <th className="p-2 text-left">Billable Pages</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="p-2">{files[0].filename}</td>
+            <td className="p-2">{wordCount}</td>
+            <td className="p-2">{complexity}</td>
+            <td className="p-2">{billablePages.toFixed(1)}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="mb-4">
+        <p>Per Page Rate: ${totals.perPageRate.toFixed(2)}</p>
+        <p>Total Billable Pages: {totals.totalBillablePages.toFixed(1)}</p>
+        <p>Certification: {totals.certType} (${totals.certPrice.toFixed(2)})</p>
+        <p className="font-semibold">Quote Total: ${totals.quoteTotal.toFixed(2)}</p>
+      </div>
+      <button onClick={onReset} className="px-4 py-2 bg-[var(--accent-color)] text-white rounded">Start Over</button>
+    </div>
+  );
+};
+
+export default QuoteResults;

--- a/netlify/functions/quote-process-background.ts
+++ b/netlify/functions/quote-process-background.ts
@@ -1,0 +1,176 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+
+interface EventLogger {
+  (step: string, message: string, progress: number): Promise<void>;
+}
+
+const handler: Handler = async (event) => {
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE, API_KEY } = process.env;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE || !API_KEY) {
+    return { statusCode: 500, body: 'Missing environment variables' };
+  }
+
+  try {
+    const { jobId } = JSON.parse(event.body || '{}');
+    if (!jobId) {
+      return { statusCode: 400, body: 'Missing jobId' };
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+
+    const log: EventLogger = async (step, message, progress) => {
+      await supabase.from('quote_job_events').insert({ job_id: jobId, step, message, progress });
+    };
+
+    const { data: job } = await supabase
+      .from('quote_jobs')
+      .select('*')
+      .eq('job_id', jobId)
+      .single();
+
+    if (!job) {
+      return { statusCode: 404, body: 'Job not found' };
+    }
+
+    await log('OCR', 'Starting OCR…', 10);
+
+    const { data: quote } = await supabase
+      .from('orders')
+      .select('*')
+      .eq('id', job.quote_id)
+      .single();
+
+    if (!quote) {
+      await log('ERROR', 'Quote not found', 100);
+      await supabase.from('quote_jobs').update({ status: 'failed', error: 'Quote not found' }).eq('job_id', jobId);
+      return { statusCode: 404, body: 'Quote not found' };
+    }
+
+    const filePath = quote.data?.filePath;
+    const { data: file } = await supabase.storage.from('orders').download(filePath);
+    const arrayBuffer = file ? await file.arrayBuffer() : null;
+    const base64 = arrayBuffer ? Buffer.from(arrayBuffer).toString('base64') : '';
+
+    const visionBody = {
+      requests: [
+        {
+          image: { content: base64 },
+          features: [{ type: 'TEXT_DETECTION' }],
+        },
+      ],
+    };
+
+    const visionResp = await fetch(
+      `https://vision.googleapis.com/v1/images:annotate?key=${API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(visionBody),
+      }
+    );
+
+    if (!visionResp.ok) {
+      const text = await visionResp.text();
+      await log('OCR', `OCR failed: ${text}`, 100);
+      await supabase.from('quote_jobs').update({ status: 'failed', error: text }).eq('job_id', jobId);
+      return { statusCode: 500, body: text };
+    }
+
+    const visionData = await visionResp.json();
+    const ocrText = visionData.responses?.[0]?.fullTextAnnotation?.text || '';
+
+    await log('OCR', 'OCR complete', 40);
+    await log('GEMINI', 'Analyzing with Gemini…', 50);
+
+    const geminiBody = {
+      contents: [
+        {
+          parts: [
+            {
+              text: `Analyze the following text and respond in JSON with fields language, documentType, complexity (Easy|Medium|Hard).\n\n${ocrText}`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const geminiResp = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(geminiBody),
+      }
+    );
+
+    if (!geminiResp.ok) {
+      const text = await geminiResp.text();
+      await log('GEMINI', `Gemini failed: ${text}`, 100);
+      await supabase.from('quote_jobs').update({ status: 'failed', error: text }).eq('job_id', jobId);
+      return { statusCode: 500, body: text }; 
+    }
+
+    const geminiData = await geminiResp.json();
+    const geminiText = geminiData.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
+    let analysis: { language?: string; documentType?: string; complexity?: string } = {};
+    try {
+      analysis = JSON.parse(geminiText);
+    } catch {
+      analysis = { result: geminiText } as any;
+    }
+
+    const wordCount = ocrText ? ocrText.trim().split(/\s+/).length : 0;
+    const complexity = (analysis.complexity as 'Easy' | 'Medium' | 'Hard') || 'Medium';
+    const complexityMap: Record<'Easy' | 'Medium' | 'Hard', number> = {
+      Easy: 1.0,
+      Medium: 1.1,
+      Hard: 1.2,
+    };
+    const complexityMultiplier = complexityMap[complexity];
+    const ppwc = wordCount * complexityMultiplier;
+    const billablePages = Math.ceil((ppwc / 240) * 10) / 10; // wordsPerPage=240
+
+    await log('GEMINI', 'Gemini analysis complete', 80);
+    await log('DB', 'Saving results…', 90);
+
+    const updated = {
+      data: {
+        ...quote.data,
+        ocrText,
+        analysis,
+        wordCount,
+        complexity,
+        complexityMultiplier,
+        ppwc,
+        billablePages,
+      },
+    };
+
+    await supabase.from('orders').update(updated).eq('id', job.quote_id);
+
+    await log('PRICING', 'Pricing complete', 100);
+    await supabase
+      .from('quote_jobs')
+      .update({ status: 'completed', updated_at: new Date().toISOString() })
+      .eq('job_id', jobId);
+
+    return { statusCode: 200, body: 'OK' };
+  } catch (error: any) {
+    const { jobId } = JSON.parse(event.body || '{}');
+    if (jobId) {
+      const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+      if (SUPABASE_URL && SUPABASE_SERVICE_ROLE) {
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        await supabase.from('quote_job_events').insert({ job_id: jobId, step: 'ERROR', message: error.message, progress: 100 });
+        await supabase
+          .from('quote_jobs')
+          .update({ status: 'failed', error: error.message })
+          .eq('job_id', jobId);
+      }
+    }
+    return { statusCode: 500, body: error.message };
+  }
+};
+
+export { handler };

--- a/netlify/functions/quote-process-background.ts
+++ b/netlify/functions/quote-process-background.ts
@@ -7,8 +7,12 @@ interface EventLogger {
 
 const handler: Handler = async (event) => {
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE, API_KEY } = process.env;
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE || !API_KEY) {
-    return { statusCode: 500, body: 'Missing environment variables' };
+  const missing = [] as string[];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (!API_KEY) missing.push('API_KEY');
+  if (missing.length) {
+    return { statusCode: 500, body: `Missing environment variables: ${missing.join(', ')}` };
   }
 
   try {

--- a/netlify/functions/quote-request.ts
+++ b/netlify/functions/quote-request.ts
@@ -11,11 +11,9 @@ const handler: Handler = async (event) => {
     return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY, API_KEY } = process.env;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE, API_KEY } = process.env;
 
-  const supabaseKey = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
-
-  if (!SUPABASE_URL || !supabaseKey || !API_KEY) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE || !API_KEY) {
     return {
       statusCode: 500,
       headers,
@@ -40,7 +38,7 @@ const handler: Handler = async (event) => {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing required fields' }) };
     }
 
-    const supabase = createClient(SUPABASE_URL, supabaseKey);
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
     const buffer = Buffer.from(fileBase64, 'base64');
     const path = `orders/${Date.now()}-${fileName}`;

--- a/netlify/functions/quote-request.ts
+++ b/netlify/functions/quote-request.ts
@@ -12,12 +12,15 @@ const handler: Handler = async (event) => {
   }
 
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE, API_KEY } = process.env;
-
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE || !API_KEY) {
+  const missing = [] as string[];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (!API_KEY) missing.push('API_KEY');
+  if (missing.length) {
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Missing environment variables' }),
+      body: JSON.stringify({ error: `Missing environment variables: ${missing.join(', ')}` }),
     };
   }
 

--- a/netlify/functions/quote-start.ts
+++ b/netlify/functions/quote-start.ts
@@ -12,12 +12,14 @@ const handler: Handler = async (event) => {
   }
 
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
-
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+  const missing = [] as string[];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (missing.length) {
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ error: 'Missing environment variables' }),
+      body: JSON.stringify({ error: `Missing environment variables: ${missing.join(', ')}` }),
     };
   }
 

--- a/netlify/functions/quote-start.ts
+++ b/netlify/functions/quote-start.ts
@@ -1,0 +1,110 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+
+const handler: Handler = async (event) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Missing environment variables' }),
+    };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const {
+      name,
+      email,
+      phone,
+      sourceLang,
+      targetLang,
+      intendedUse,
+      fileName,
+      fileType,
+      fileBase64,
+    } = body;
+
+    if (!name || !email || !sourceLang || !targetLang || !intendedUse || !fileName || !fileType || !fileBase64) {
+      return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing required fields' }) };
+    }
+
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+
+    const buffer = Buffer.from(fileBase64, 'base64');
+    const path = `orders/${Date.now()}-${fileName}`;
+    const { error: uploadError } = await supabase.storage
+      .from('orders')
+      .upload(path, buffer, { contentType: fileType });
+
+    if (uploadError) throw uploadError;
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('orders')
+      .insert({
+        name,
+        email,
+        phone,
+        data: { sourceLang, targetLang, intendedUse, filePath: path },
+      })
+      .select('id')
+      .single();
+
+    if (insertError) throw insertError;
+
+    const { data: job, error: jobError } = await supabase
+      .from('quote_jobs')
+      .insert({ quote_id: inserted.id, status: 'pending' })
+      .select('job_id')
+      .single();
+
+    if (jobError) throw jobError;
+
+    await supabase.from('quote_job_events').insert({
+      job_id: job.job_id,
+      step: 'UPLOAD',
+      message: 'File uploaded',
+      progress: 10,
+    });
+
+    const host = event.headers['x-forwarded-host'] || event.headers['host'];
+    const proto = event.headers['x-forwarded-proto'] || 'https';
+    const url = new URL('/.netlify/functions/quote-process-background', `${proto}://${host}`);
+
+    const resp = await fetch(url.toString(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jobId: job.job_id }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text);
+    }
+
+    return {
+      statusCode: 202,
+      headers,
+      body: JSON.stringify({ jobId: job.job_id }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: error.message || 'Unknown error' }),
+    };
+  }
+};
+
+export { handler };
+

--- a/netlify/functions/quote-status.ts
+++ b/netlify/functions/quote-status.ts
@@ -13,8 +13,15 @@ const handler: Handler = async (event) => {
   }
 
   const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
-    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Missing environment variables' }) };
+  const missing = [] as string[];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (missing.length) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: `Missing environment variables: ${missing.join(', ')}` }),
+    };
   }
 
   const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);

--- a/netlify/functions/quote-status.ts
+++ b/netlify/functions/quote-status.ts
@@ -1,0 +1,55 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+
+const handler: Handler = async (event) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  const { jobId } = event.queryStringParameters || {};
+  if (!jobId) {
+    return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing jobId' }) };
+  }
+
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Missing environment variables' }) };
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+
+  const { data: job, error: jobError } = await supabase
+    .from('quote_jobs')
+    .select('*')
+    .eq('job_id', jobId)
+    .single();
+
+  if (jobError || !job) {
+    return { statusCode: 404, headers, body: JSON.stringify({ error: 'Job not found' }) };
+  }
+
+  const { data: events } = await supabase
+    .from('quote_job_events')
+    .select('*')
+    .eq('job_id', jobId)
+    .order('ts', { ascending: true });
+
+  let result = null;
+  if (job.status === 'completed') {
+    const { data: quote } = await supabase
+      .from('orders')
+      .select('*')
+      .eq('id', job.quote_id)
+      .single();
+    result = quote;
+  }
+
+  return {
+    statusCode: 200,
+    headers,
+    body: JSON.stringify({ job, events: events || [], result }),
+  };
+};
+
+export { handler };

--- a/netlify/functions/supabase.ts
+++ b/netlify/functions/supabase.ts
@@ -6,15 +6,14 @@ import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
  * It fetches the top 1 record from a 'notes' table.
  */
 const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
-  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY } = process.env;
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE } = process.env;
 
   const headers = {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*', // Allow requests from any origin
   };
 
-  const supabaseKey = SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY;
-  if (!SUPABASE_URL || !supabaseKey) {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
     return {
       statusCode: 500,
       body: JSON.stringify({ error: 'Supabase environment variables are not set in the Netlify dashboard.' }),
@@ -23,7 +22,7 @@ const handler: Handler = async (event: HandlerEvent, context: HandlerContext) =>
   }
 
   try {
-    const supabase = createClient(SUPABASE_URL, supabaseKey);
+    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
 
     // Perform a simple query to test the connection and credentials
     const { data, error } = await supabase

--- a/netlify/functions/supabase.ts
+++ b/netlify/functions/supabase.ts
@@ -13,10 +13,13 @@ const handler: Handler = async (event: HandlerEvent, context: HandlerContext) =>
     'Access-Control-Allow-Origin': '*', // Allow requests from any origin
   };
 
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+  const missing = [] as string[];
+  if (!SUPABASE_URL) missing.push('SUPABASE_URL');
+  if (!SUPABASE_SERVICE_ROLE) missing.push('SUPABASE_SERVICE_ROLE');
+  if (missing.length) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Supabase environment variables are not set in the Netlify dashboard.' }),
+      body: JSON.stringify({ error: `Missing environment variables: ${missing.join(', ')}` }),
       headers,
     };
   }


### PR DESCRIPTION
## Summary
- create quote jobs and events, triggering background OCR/Gemini processing
- add status endpoint and frontend screens for waiting logs, results, and errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4e4de08288330a94425e8fe87777e